### PR TITLE
fix fenrog issue 35

### DIFF
--- a/Config/supersid.cfg
+++ b/Config/supersid.cfg
@@ -61,14 +61,14 @@ frequency = 18200
 [Capture]
 # Linux example using alsaaudio
 Audio = alsaaudio
-Card = plughw:CARD=Generic,DEV=0
+Device = plughw:CARD=Generic,DEV=0
 Format = S16_LE
 PeriodSize = 1024
 
 # Windows example using either sounddevice or pyaudio
 # Audio = sounddevice
 # Audio = pyaudio
-# Card = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
+# Device = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
 # Format = S32_LE
 
 [FTP]

--- a/docs/ConfigHelp.md
+++ b/docs/ConfigHelp.md
@@ -35,7 +35,7 @@ This section groups most of the parameters identifying your SuperSID monitor. So
   
 ### Log Parameters
 
-  * audio_sampling_rate: **48000** or **96000** (you can experiment with other value as long as your card support them)
+  * audio_sampling_rate: **48000** or **96000** (you can experiment with other value as long as your device supports them)
   * log_interval: number of second between two reading. Default is '**5**' seconds. Reading/sound capture last one second.
   * log_type: **filtered** or **raw**. When **filtered** is indicated, *bema_wing* function is called to smoothen raw data before writting the file else in **raw** mode, captured data are written 'as is'. Note that *sidfile.py* can be used as an utility to apply 'bema_wing' function to an existing file (raw or not) to smoothen its data.
   * data_path: fully qualified path where files will be written. If not mentioned then '../Data/' is used. If the path is relative, then it is relative to the script folder.
@@ -75,7 +75,8 @@ Each station to monitor is enumerated from 1 till n=*number_of_stations*. For ea
 This section can be omitted if you plan to use the 'pyaudio' library. If you want to use the "alsaaudio" library then you can declare:
 
   * Audio: python library to use **alsaaudio** (default for Linux), **sounddevice** (default for Windows) or **pyaudio**
-  * Card: card name for capture. **plughw:CARD=Generic,DEV=0** (default for Linux), **MME: Microsoft Sound Mapper - Input** (default for Windows).
+  * Card: [for alsaaudio only] card name for capture. The card name is incomplete, thus alsaaudio is guessing the device name. This is deprecated, use Device instead.
+  * Device: device name for capture. **plughw:CARD=Generic,DEV=0** (default for Linux), **MME: Microsoft Sound Mapper - Input** (default for Windows).
   * Format: **S16_LE** (default), **S24_3LE**, **S32_LE**
   * PeriodSize: [for alsaaudio only] period size for capture. Default is '1024'.
   

--- a/docs/SuperSIDonLinux.md
+++ b/docs/SuperSIDonLinux.md
@@ -65,7 +65,7 @@ Numpy also requires a special package (for opening `shared object (.so)` files):
 ### 3.1) optional virtual environment
 
 This step is optional. Creating your own environment allows to install libraries in all freedom,
-without `sudo` and ensure you have a coherent and working set of libraries (soundcard).
+without `sudo` and ensure you have a coherent and working set of libraries (sound card).
 If your Raspi is dedicated to SuperSID then you can skip this step and install all globally.
 
 From /home/pi:
@@ -150,9 +150,9 @@ SD card of 16 MB or more
 ```
 
 
-## 5) Choose your USB Soundcard
+## 5) Choose your USB Sound Card
 
-Execute first the command `alsamixer` to ensure that the card is recorgnized and in proper order of functioning.
+Execute first the command `alsamixer` to ensure that the sound card is recorgnized and in proper order of functioning.
 Make sure that sound can be captured from it, and that the input volume is between 80 and 90.
 
 Read the help of find_alsa_devices.py and follow it.
@@ -187,7 +187,7 @@ In one console generate the test frequency.
 In another console search for the suitable device. Replace 'CARD=Generic' with the device of interrest.
 ```console
     $ cd ~/supersid/supersid
-    $ python3 -u find_alsa_devices.py -t=external -c=CARD=Generic 2>&1 | grep OK
+    $ python3 -u find_alsa_devices.py -t=external -d="CARD=Generic" 2>&1 | grep OK
 ```
 
 Lets assume, you got the output below (actually it is much longer, these are just two interresting snippets).
@@ -251,7 +251,7 @@ The corresponding lines of the configuration file 'supersid.cfg':
 
     [Capture]
     Audio = alsaaudio
-    Card = plughw:CARD=Generic,DEV=0
+    Device = plughw:CARD=Generic,DEV=0
     Format = S32_LE
     PeriodSize = 1024
 ```

--- a/docs/SuperSIDonRaspi3.md
+++ b/docs/SuperSIDonRaspi3.md
@@ -52,7 +52,7 @@ Numpy also requires a special package (for opening `shared object (.so)` files):
 ### 3.1) optional virtual environment
 
 This step is optional. Creating your own environment allows to install libraries in all freedom,
-without `sudo` and ensure you have a coherent and working set of libraries (soundcard).
+without `sudo` and ensure you have a coherent and working set of libraries (sound card).
 If your Raspi is dedicated to SuperSID then you can skip this step and install all globally.
 
 From /home/pi:
@@ -149,9 +149,9 @@ SD card of 16 MB or more
 ```
 
 
-## 5) Choose your USB Soundcard
+## 5) Choose your USB Sound Card
 
-Execute first the command `alsamixer` to ensure that the card is recorgnized and in proper order of functioning.
+Execute first the command `alsamixer` to ensure that the sound card is recorgnized and in proper order of functioning.
 Make sure that sound can be captured from it, and that the input volume is between 80 and 90.
 
 Read the help of find_alsa_devices.py and follow it.
@@ -186,7 +186,7 @@ In one console generate the test frequency.
 In another console search for the suitable device. Replace 'plughw:CARD=Dongle,DEV=0' with the device of interrest.
 ```console
     $ cd ~/supersid/supersid
-    $ python3 -u find_alsa_devices.py -t=external -c=plughw:CARD=Dongle,DEV=0 2>&1 | grep OK
+    $ python3 -u find_alsa_devices.py -t=external -d="plughw:CARD=Dongle,DEV=0" 2>&1 | grep OK
 ```
 
 Lets assume, you got the output below (actually it is much longer, this is just an interresting snippet).
@@ -236,7 +236,7 @@ The corresponding lines of the configuration file 'supersid.cfg':
 
     [Capture]
     Audio = alsaaudio
-    Card = plughw:CARD=Dongle,DEV=0
+    Device = plughw:CARD=Dongle,DEV=0
     Format = S24_3LE
     PeriodSize = 1024
 ```

--- a/docs/SuperSIDonWindows.md
+++ b/docs/SuperSIDonWindows.md
@@ -110,9 +110,9 @@ To update (pull) to the latest version, do:
 ```
 
 
-## 3) Choose your Soundcard
+## 3) Choose your Sound Card
 
-Identify the available audio library / host API / audio card / sample rate combinations. If you have grep available, you can filter the results.
+Identify the available audio library / host API / audio device / sample rate combinations. If you have grep available, you can filter the results.
 
 The [Thesycon USB Descriptor Dumper](https://www.thesycon.de/eng/usb_descriptordumper.shtml) may give you some insights about the device capabilities. I.e. supportde sample rate and bits per sample.
 
@@ -160,7 +160,7 @@ The corresponding lines of the configuration file 'supersid.cfg':
 
     [Capture]
     Audio = sounddevice
-    Card = MME: Microsoft Sound Mapper - Input
+    Device = MME: Microsoft Sound Mapper - Input
     Format = S32_LE
 ```
 

--- a/supersid/config.py
+++ b/supersid/config.py
@@ -97,16 +97,16 @@ class Config(dict):
             ),
 
             'Capture': (
-                ("Audio", str, 'alsaaudio'),        # soundcard: alsaaudio, sounddevice, pyaudio
-                ("Card", str, 'plughw:CARD=Generic,DEV=0'), # alsaaudio, sounddevice, pyaudio: card name for capture
-                ("Device", str, ''),                # alsaaudio: obsolete (all are using fully qualified Card names)
+                ("Audio", str, 'alsaaudio'),        # audio module: alsaaudio, sounddevice, pyaudio
+                ("Device", str, 'plughw:CARD=Generic,DEV=0'), # alsaaudio, sounddevice, pyaudio: Device name for capture
+                ("Card", str, ''),                  # alsaaudio: obsolete (all audio modules are using fully qualified Device names)
                 ("PeriodSize", int, 1024),          # alsaaudio: period size for capture
-                ("Format", str, 'S16_LE'),          # alsaaudio: format S16_LE, S24_3LE, S24_LE
+                ("Format", str, 'S16_LE'),          # alsaaudio: format S16_LE, S24_3LE, S32_LE
             ),
 
             'Linux': (                              # obsolete
                 ("Audio", str, 'alsaaudio'),        # obsolete
-                ("Card", str, 'plughw:CARD=Generic,DEV=0'),  # obsolete
+                ("Card", str, ''),                  # obsolete
                 ("PeriodSize", int, 1024),          # obsolete
             ),
 
@@ -130,9 +130,9 @@ class Config(dict):
 
         if sys.platform.startswith('win32'):
             sections['Capture'] = (
-                ("Audio", str, 'sounddevice'),                          # soundcard: sounddevice, pyaudio
-                ("Card", str, 'MME: Microsoft Sound Mapper - Input'),   # sounddevice, pyaudio: card name for capture
-                ("Format", str, 'S16_LE'),                              # alsaaudio: format S16_LE, S24_3LE, S24_LE
+                ("Audio", str, 'sounddevice'),                          # audio module: sounddevice, pyaudio
+                ("Device", str, 'MME: Microsoft Sound Mapper - Input'), # sounddevice, pyaudio: Device name for capture
+                ("Format", str, 'S16_LE'),                              # alsaaudio: format S16_LE, S24_3LE, S32_LE
             )
 
         self.sectionfound = set()
@@ -159,7 +159,6 @@ class Config(dict):
                     self.sectionfound.add(section)
 
         if "Linux" in self.sectionfound:
-            self.config_ok = False
             print ("\n*** WARNING***\nSection [Linux] is obsolete.\nPlease replace it by [Capture] in your .cfg files.\n")
 
         # Getting the stations parameters
@@ -275,11 +274,10 @@ class Config(dict):
         if "Audio" not in self:
             self["Audio"] = "sounddevice"
 
-        # obsolete Device
-        if 'Device' in self:
-            if self['Device']:
-                self.config_ok = False
-                print ("\n*** WARNING***\n'Device' is obsolete.\nPlease replace it by fully qualified 'Card' in your .cfg files.\n")
+        # obsolete Card
+        if 'Card' in self:
+            if self['Card']:
+                print ("\n*** WARNING***\n'Card' is obsolete.\nPlease replace it by fully qualified 'Device' in your .cfg files.\n")
                 return
 
         # when present, 'Format' must be one of the supported formats (relevant for the format conversion in sampler.py for alsaaudio)

--- a/supersid/supersid_scanner.py
+++ b/supersid/supersid_scanner.py
@@ -232,13 +232,13 @@ if __name__ == '__main__':
 
         config = readConfig(args.config_file)
         config.supersid_check()
-        card = pyaudio_soundcard(config['Card'], RATE)
-        frames = card.capture(SEC)
-        card.close()
+        device = pyaudio_soundcard(config['Device'], RATE, 'S16_LE')
+        frames = device.capture(SEC)
+        device.close()
 
         wf = wave.open("record_test.wav", 'wb')
         wf.setnchannels(1)
-        wf.setsampwidth(card.pa_lib.get_sample_size(card.FORMAT))
+        wf.setsampwidth(device.pa_lib.get_sample_size(device.FORMAT_MAP[device.format]))
         wf.setframerate(RATE)
         wf.writeframes(bytearray(frames))
         wf.close()


### PR DESCRIPTION
For backward compatibility the old Card configuration with partial name and device guessing shall be re-implemented similar to the previous sberl implementation. What has been configured as Card in my fork shall be named Device. A deprecation warning shall be added when the old Card is used.

Rational:
[pyalsaaudio deprecation of card](https://larsimmisch.github.io/pyalsaaudio/libalsaaudio.html#:~:text=format%20and%20periodsize.-,Changed%20in%200.8%3A,card.%20This%20was%20always%20fragile%20and%20broke%20some%20legitimate%20usecases.,-PCM%20objects%20have)